### PR TITLE
Fix lombok-jackson serialization for ServiceRecord

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <properties>
     <lombok.version>1.18.8</lombok.version>
     <jackson.version>2.9.8</jackson.version>
-    <docker-java.version>3.1.2</docker-java.version>
+    <docker-java.version>3.1.3</docker-java.version>
     <httpclient.version>4.5.6</httpclient.version>
     <httpcore.version>4.4.10</httpcore.version>
   </properties>

--- a/src/main/java/com/github/dockerunit/discovery/consul/ServiceRecord.java
+++ b/src/main/java/com/github/dockerunit/discovery/consul/ServiceRecord.java
@@ -5,77 +5,81 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.Wither;
 
 @Wither
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ServiceRecord {
 
-	@JsonProperty("ServiceName")
-	private final String name;
-	
-	@JsonProperty("Address")
-	private final String address;
-	
-	@JsonProperty("ServicePort")
-	private final int port;
+    @JsonProperty("ServiceName")
+    private String name;
 
-	@JsonProperty("ServiceAddress")
-	private String serviceAddress;
-	
-	@JsonProperty("Service")
-	private final Service service;
-	
-	@JsonProperty("Checks")
-	private final List<Check> checks;
-	
-	
-	public String getName() {
-		return service != null ? service.getName() : name; 
-	}
-	
-	public String getAddress() {
-		return service != null ? service.getAddress() : address;
-	}
-	
-	public int getPort() {
-		return service != null ? service.getPort() : port;
-	}
+    @JsonProperty("Address")
+    private String address;
 
-	@Wither
-	@Getter
-	@AllArgsConstructor
-	@JsonIgnoreProperties(ignoreUnknown = true)
-	public static class Service {
-		
-		@JsonProperty("Service")
-		private final String name;
-		
-		@JsonProperty("Address")
-		private final String address;
-		
-		@JsonProperty("Port")
-		private final int port;
-		
-	}
-	
-	@Wither
-	@Getter
-	@AllArgsConstructor
-	@JsonIgnoreProperties(ignoreUnknown = true)
-	public static class Check {
-		
-		public static final String PASSING = "passing";
+    @JsonProperty("ServicePort")
+    private int port;
 
-		@JsonProperty("Name")
-		private final String name;
-		
-		@JsonProperty("Status")
-		private final String status;
-		
-	}
+    @JsonProperty("ServiceAddress")
+    private String serviceAddress;
+
+    @JsonProperty("Service")
+    private Service service;
+
+    @JsonProperty("Checks")
+    private List<Check> checks;
+
+    public String getName() {
+        return service != null ? service.getName() : name;
+    }
+
+    public String getAddress() {
+        return service != null ? service.getAddress() : address;
+    }
+
+    public int getPort() {
+        return service != null ? service.getPort() : port;
+    }
+
+    @Wither
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Service {
+
+        @JsonProperty("Service")
+        private String name;
+
+        @JsonProperty("Address")
+        private String address;
+
+        @JsonProperty("Port")
+        private int port;
+
+    }
+
+    @Wither
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Check {
+
+        public static final String PASSING = "passing";
+
+        @JsonProperty("Name")
+        private String name;
+
+        @JsonProperty("Status")
+        private String status;
+
+    }
 }


### PR DESCRIPTION
- In the version of lombok `1.16.18` there was an annotation that was used on the created ctors that is @ConstructorProperties.  This annotation was used by Jackson for serializating correctly the object, but in the new version of lombok, that is `1.18.8` that was not generated anymore. 
For this reason, the serialization of the object ServiceRecord, without an empty ctor, was failing.

Thanks to Iker that spotted that during the tests!
