### PR TITLE
Make Consul image configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [semantic versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+
+## 0.1.1 [11 Nov 2020]
+
+### Changed
+
+- Bumped `lombok` to version `1.8.16`;
+- Bumped `jackson` to version `2.11.3`;
+- Bumped `httpcore` to version `4.4.13`;
+- Introduced new system property called `consul.image` for overriding the default DockerHub Consul image;
+- Minor formatting changes.
+
+## 0.1.0 [01 Mar 2019]
+
 ### Changed
 
 - Bump docker-java to 3.1.1
@@ -19,13 +32,4 @@ and this project adheres to [semantic versioning](https://semver.org/spec/v2.0.0
 
 - Goodbye to gliderlabs/registrator
 - Goodbye to `qzagarese` in package names :-) 
-
-## 1.0.1 [01 Mar 2019]
-
-### Added
-
-- New boolean flag `-Dconsul.dns.enabled` to disable consul DNS (fixes [#12](https://github.com/qzagarese/dockerunit/issues/12)) 
-
-## 1.0.0 [06 Feb 2019]
-
-_Initial Release_
+- New boolean flag `-Dconsul.dns.enabled` to disable Consul DNS (fixes [#12](https://github.com/qzagarese/dockerunit/issues/12)) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,30 +6,28 @@ and this project adheres to [semantic versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-
-## 0.1.1 [11 Nov 2020]
-
-### Changed
-
-- Bumped `lombok` to version `1.8.16`;
-- Bumped `jackson` to version `2.11.3`;
-- Bumped `httpcore` to version `4.4.13`;
-- Introduced new system property called `consul.image` for overriding the default DockerHub Consul image;
-- Minor formatting changes.
-
-## 0.1.0 [01 Mar 2019]
+## 0.1.1 - (11 Nov 2020)
 
 ### Changed
 
-- Bump docker-java to 3.1.1
-- Rewritten discovery to utilise containers internal IPs and ports
-- Renamed `@EnableConsul` to `@TCPHealthCheck` and its property `exposedPort` to `port`
-- Renamed property `exposedPort` in `@WebHealthCheck` to `port`
-- `@UseConsulDns` now sets the Consul container IP (instead of the Docker bridge one) as primary DNS for your containers and this makes it usable on MacOS 
+  - Bumped `lombok` to version `1.8.16`
+  - Bumped `jackson` to version `2.11.3`
+  - Bumped `httpcore` to version `4.4.13`
+  - Introduced new system property called `consul.image` for overriding the default DockerHub Consul image
+  - Minor formatting changes
 
+## [0.1.0] - (01 Mar 2019)
+
+### Changed
+
+  - Bump docker-java to 3.1.1
+  - Rewritten discovery to utilise containers internal IPs and ports
+  - Renamed `@EnableConsul` to `@TCPHealthCheck` and its property `exposedPort` to `port`
+  - Renamed property `exposedPort` in `@WebHealthCheck` to `port`
+  - `@UseConsulDns` now sets the Consul container IP (instead of the Docker bridge one) as primary DNS for your containers and this makes it usable on MacOS 
 
 ### Removed
 
-- Goodbye to gliderlabs/registrator
-- Goodbye to `qzagarese` in package names :-) 
-- New boolean flag `-Dconsul.dns.enabled` to disable Consul DNS (fixes [#12](https://github.com/qzagarese/dockerunit/issues/12)) 
+  - Goodbye to gliderlabs/registrator
+  - Goodbye to `qzagarese` in package names :-)
+  - New boolean flag `-Dconsul.dns.enabled` to disable Consul DNS (fixes [#12](https://github.com/qzagarese/dockerunit/issues/12)) 

--- a/README.md
+++ b/README.md
@@ -72,3 +72,7 @@ by using the `service-b.service.consul` name.
 - `service-b` is not declaring any `@PortBinding` because our test does not need to talk to it.
 Only `service-a` will talk to it, but it can do it by using the container IP to which
 the `service-b.service.consul` name resolves to.
+
+---
+By default, the `dockerunit-consul` module uses Consul Docker image from DockerHub.
+To override the default using a different Consul Docker image the System property `consul.image` can be provided.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.github.dockerunit</groupId>
     <artifactId>dockerunit-parent</artifactId>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <relativePath/>
   </parent>
 
@@ -24,10 +24,10 @@
 
   <properties>
     <lombok.version>1.18.16</lombok.version>
-    <jackson.version>2.9.8</jackson.version>
+    <jackson.version>2.11.3</jackson.version>
     <docker-java.version>3.1.5</docker-java.version>
     <httpclient.version>4.5.6</httpclient.version>
-    <httpcore.version>4.4.11</httpcore.version>
+    <httpcore.version>4.4.13</httpcore.version>
   </properties>
 
   <dependencyManagement>

--- a/src/main/java/com/github/dockerunit/discovery/consul/ConsulDiscoveryConfig.java
+++ b/src/main/java/com/github/dockerunit/discovery/consul/ConsulDiscoveryConfig.java
@@ -1,21 +1,26 @@
 package com.github.dockerunit.discovery.consul;
 
-import com.github.dockerunit.core.annotation.WithSvc;
-
 import static com.github.dockerunit.discovery.consul.ConsulDiscoveryConfig.CONSUL_CONTAINER_NAME;
 
-@WithSvc(svc =ConsulDescriptor.class, containerNamePrefix =CONSUL_CONTAINER_NAME)
+import com.github.dockerunit.core.annotation.WithSvc;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@WithSvc(svc = ConsulDescriptor.class, containerNamePrefix = CONSUL_CONTAINER_NAME)
 public class ConsulDiscoveryConfig {
 
-	public static final String DOCKER_BRIDGE_IP_PROPERTY = "docker.bridge.ip";
-	public static final String DOCKER_BRIDGE_IP_DEFAULT = "172.17.42.1";
-	public static final String DOCKER_HOST_PROPERTY = "docker.host";
-	public static final String SERVICE_DISCOVERY_TIMEOUT = "service.discovery.timeout";
-	public static final String SERVICE_DISCOVERY_TIMEOUT_DEFAULT = "30";
-	public static final String CONSUL_POLLING_PERIOD = "consul.polling.period";
-	public static final String CONSUL_POLLING_PERIOD_DEFAULT = "1";
-	public static final String CONSUL_DNS_ENABLED_PROPERTY = "consul.dns.enabled";
-	public static final String CONSUL_DNS_ENABLED_DEFAULT = "true";
-	public static final String CONSUL_CONTAINER_NAME = "consul";
+    public static final String DOCKER_BRIDGE_IP_PROPERTY = "docker.bridge.ip";
+    public static final String DOCKER_BRIDGE_IP_DEFAULT = "172.17.42.1";
+    public static final String DOCKER_HOST_PROPERTY = "docker.host";
+    public static final String SERVICE_DISCOVERY_TIMEOUT = "service.discovery.timeout";
+    public static final String SERVICE_DISCOVERY_TIMEOUT_DEFAULT = "30";
+    public static final String CONSUL_POLLING_PERIOD = "consul.polling.period";
+    public static final String CONSUL_POLLING_PERIOD_DEFAULT = "1";
+    public static final String CONSUL_DNS_ENABLED_PROPERTY = "consul.dns.enabled";
+    public static final String CONSUL_DNS_ENABLED_DEFAULT = "true";
+    public static final String CONSUL_CONTAINER_NAME = "consul";
+    public static final String CONSUL_IMAGE = "consul.image";
+    public static final String CONSUL_DEFAULT_IMAGE = "consul:1.4.4";
 
 }

--- a/src/main/java/com/github/dockerunit/discovery/consul/ConsulDiscoveryProvider.java
+++ b/src/main/java/com/github/dockerunit/discovery/consul/ConsulDiscoveryProvider.java
@@ -1,7 +1,21 @@
 package com.github.dockerunit.discovery.consul;
 
+import static com.github.dockerunit.discovery.consul.ConsulDiscoveryConfig.CONSUL_POLLING_PERIOD;
+import static com.github.dockerunit.discovery.consul.ConsulDiscoveryConfig.CONSUL_POLLING_PERIOD_DEFAULT;
+import static com.github.dockerunit.discovery.consul.ConsulDiscoveryConfig.DOCKER_BRIDGE_IP_DEFAULT;
+import static com.github.dockerunit.discovery.consul.ConsulDiscoveryConfig.DOCKER_BRIDGE_IP_PROPERTY;
+import static com.github.dockerunit.discovery.consul.ConsulDiscoveryConfig.DOCKER_HOST_PROPERTY;
+import static com.github.dockerunit.discovery.consul.ConsulDiscoveryConfig.SERVICE_DISCOVERY_TIMEOUT;
+import static com.github.dockerunit.discovery.consul.ConsulDiscoveryConfig.SERVICE_DISCOVERY_TIMEOUT_DEFAULT;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerunit.core.Service;
 import com.github.dockerunit.core.ServiceContext;
 import com.github.dockerunit.core.ServiceInstance;
@@ -11,140 +25,143 @@ import com.github.dockerunit.core.internal.docker.DefaultDockerClientProvider;
 import com.github.dockerunit.core.internal.service.DefaultServiceContext;
 import com.github.dockerunit.discovery.consul.annotation.TCPHealthCheck;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static com.github.dockerunit.discovery.consul.ConsulDiscoveryConfig.*;
-
 public class ConsulDiscoveryProvider implements DiscoveryProvider {
 
-	private static final String DOCKER_HOST = System.getProperty(DOCKER_HOST_PROPERTY, 
-			System.getProperty(DOCKER_BRIDGE_IP_PROPERTY, DOCKER_BRIDGE_IP_DEFAULT));
-	private final ConsulHttpResolver resolver;
-	private final ConsulRegistrator registrator;
-	private final DockerClient dockerClient;
-	private final int discoveryTimeout;
-	private final int consulPollingPeriod;
-	
-	static final String CONSUL_DNS_SUFFIX = ".service.consul";
-	
-	public ConsulDiscoveryProvider() {
-		resolver = new ConsulHttpResolver(DOCKER_HOST, ConsulDescriptor.CONSUL_PORT);
-		discoveryTimeout = Integer.parseInt(System.getProperty(SERVICE_DISCOVERY_TIMEOUT, 
-				SERVICE_DISCOVERY_TIMEOUT_DEFAULT));
-		consulPollingPeriod = Integer.parseInt(System.getProperty(CONSUL_POLLING_PERIOD, CONSUL_POLLING_PERIOD_DEFAULT));
-		dockerClient = new DefaultDockerClientProvider().getClient();
-		registrator = new ConsulRegistrator(dockerClient, consulPollingPeriod, DOCKER_HOST, ConsulDescriptor.CONSUL_PORT);
-	}
-	
-	@Override
-	public Class<?> getDiscoveryConfig() {
-		return ConsulDiscoveryConfig.class;
-	}
+    private static final String DOCKER_HOST = System.getProperty(
+            DOCKER_HOST_PROPERTY,
+            System.getProperty(DOCKER_BRIDGE_IP_PROPERTY, DOCKER_BRIDGE_IP_DEFAULT)
+    );
+    private final ConsulHttpResolver resolver;
+    private final ConsulRegistrator registrator;
+    private final DockerClient dockerClient;
+    private final int discoveryTimeout;
+    private final int consulPollingPeriod;
 
-	@Override
-	public ServiceContext populateRegistry(ServiceContext context) {
-		trackContext(context);
-		Set<Service> services = context.getServices().stream()
-				.map(s -> doDiscovery(s))
-				.collect(Collectors.toSet());
-		return new DefaultServiceContext(services);
-	}
+    static final String CONSUL_DNS_SUFFIX = ".service.consul";
 
-	private void trackContext(ServiceContext context) {
-		context.getServices().stream()
-				.forEach(svc -> svc.getInstances()
-						.stream()
-						.forEach(si -> registrator.trackContainer(si.getContainerId())));
-	}
+    public ConsulDiscoveryProvider() {
+        resolver = new ConsulHttpResolver(DOCKER_HOST, ConsulDescriptor.CONSUL_PORT);
+        discoveryTimeout = Integer.parseInt(
+                System.getProperty(SERVICE_DISCOVERY_TIMEOUT, SERVICE_DISCOVERY_TIMEOUT_DEFAULT)
+        );
+        consulPollingPeriod = Integer.parseInt(
+                System.getProperty(CONSUL_POLLING_PERIOD, CONSUL_POLLING_PERIOD_DEFAULT)
+        );
+        dockerClient = new DefaultDockerClientProvider().getClient();
+        registrator = new ConsulRegistrator(
+                dockerClient,
+                consulPollingPeriod,
+                DOCKER_HOST,
+                ConsulDescriptor.CONSUL_PORT
+        );
+    }
 
-	@Override
-	public ServiceContext clearRegistry(ServiceContext currentContext, ServiceContext globalContext) {
-		Set<Service> services = currentContext.getServices().stream()
-				.map(s -> doCleanup(s, globalContext.getService(s.getName())))
-				.collect(Collectors.toSet());
-		return new DefaultServiceContext(services);
-	}
+    @Override
+    public Class<?> getDiscoveryConfig() {
+        return ConsulDiscoveryConfig.class;
+    }
 
-	private Service doDiscovery(Service s) {
-		List<ServiceRecord> records;
-		try {
-			records = resolver.resolveService(s.getName(), s.getInstances().size(), 
-					discoveryTimeout, consulPollingPeriod, extractInitialDelay(s.getDescriptor()));
-		} catch (Exception e) {
-			return s.withInstances(s.getInstances().stream()
-					.map(i -> i.withStatus(ServiceInstance.Status.ABORTED)
-							.withStatusDetails(e.getMessage()))
-					.collect(Collectors.toSet()));
-		}
-		
-		Set<ServiceInstance> withPorts = s.getInstances().stream()
-				.map(si -> {
-					InspectContainerResponse r = dockerClient.inspectContainerCmd(si.getContainerId()).exec();
-					return si.withPort(findPort(r, records).orElse(0))
-							.withIp(DOCKER_HOST)
-							.withStatus(ServiceInstance.Status.DISCOVERED)
-							.withStatusDetails("Discovered via consul");
-				}).collect(Collectors.toSet());
-		
-		return s.withInstances(withPorts);
-	}
+    @Override
+    public ServiceContext populateRegistry(ServiceContext context) {
+        trackContext(context);
+        Set<Service> services = context.getServices().stream()
+                .map(this::doDiscovery)
+                .collect(Collectors.toSet());
 
-	private int extractInitialDelay(ServiceDescriptor descriptor) {
-	    return descriptor.getOptions().stream()
-	        .filter(TCPHealthCheck.class::isInstance)
-	        .findFirst()
-	        .map(TCPHealthCheck.class::cast)
-	        .map(TCPHealthCheck::initialDelay)
-	        .orElse(0);
+        return new DefaultServiceContext(services);
+    }
+
+    private void trackContext(ServiceContext context) {
+        context.getServices()
+                .forEach(svc -> svc.getInstances().forEach(si -> registrator.trackContainer(si.getContainerId())));
+    }
+
+    @Override
+    public ServiceContext clearRegistry(ServiceContext currentContext, ServiceContext globalContext) {
+        Set<Service> services = currentContext.getServices().stream()
+                .map(s -> doCleanup(s, globalContext.getService(s.getName())))
+                .collect(Collectors.toSet());
+
+        return new DefaultServiceContext(services);
+    }
+
+    private Service doDiscovery(Service s) {
+        List<ServiceRecord> records;
+        try {
+            records = resolver.resolveService(s.getName(), s.getInstances().size(),
+                    discoveryTimeout, consulPollingPeriod, extractInitialDelay(s.getDescriptor()));
+        } catch (Exception e) {
+            return s.withInstances(s.getInstances().stream()
+                    .map(i -> i.withStatus(ServiceInstance.Status.ABORTED)
+                            .withStatusDetails(e.getMessage()))
+                    .collect(Collectors.toSet()));
+        }
+
+        Set<ServiceInstance> withPorts = s.getInstances().stream()
+                .map(si -> {
+                    InspectContainerResponse r = dockerClient.inspectContainerCmd(si.getContainerId()).exec();
+                    return si.withPort(findPort(r, records).orElse(0))
+                            .withIp(DOCKER_HOST)
+                            .withStatus(ServiceInstance.Status.DISCOVERED)
+                            .withStatusDetails("Discovered via consul");
+                }).collect(Collectors.toSet());
+
+        return s.withInstances(withPorts);
+    }
+
+    private int extractInitialDelay(ServiceDescriptor descriptor) {
+        return descriptor.getOptions().stream()
+                .filter(TCPHealthCheck.class::isInstance)
+                .findFirst()
+                .map(TCPHealthCheck.class::cast)
+                .map(TCPHealthCheck::initialDelay)
+                .orElse(0);
     }
 
     private Service doCleanup(Service current, Service global) {
-		try {
-			int expectedRecords = global != null? global.getInstances().size() : 0;
-			resolver.verifyCleanup(current.getName() + CONSUL_DNS_SUFFIX, expectedRecords, discoveryTimeout, consulPollingPeriod);
-			return current;
-		} catch (Exception e) {
-			return current.withInstances(current.getInstances().stream()
-				.map(si -> si.withStatus(ServiceInstance.Status.TERMINATION_FAILED)
-						.withStatusDetails(e.getMessage()))
-				.collect(Collectors.toSet()));
-		}
-	}
+        try {
+            int expectedRecords = global != null ? global.getInstances().size() : 0;
+            resolver.verifyCleanup(current.getName() + CONSUL_DNS_SUFFIX,
+                    expectedRecords,
+                    discoveryTimeout,
+                    consulPollingPeriod);
+            return current;
+        } catch (Exception e) {
+            return current.withInstances(current.getInstances().stream()
+                    .map(si -> si.withStatus(ServiceInstance.Status.TERMINATION_FAILED)
+                            .withStatusDetails(e.getMessage()))
+                    .collect(Collectors.toSet()));
+        }
+    }
 
-	private Optional<Integer> findPort(InspectContainerResponse response, List<ServiceRecord> records) {
-		return records.stream()
-	        .filter(r -> matchRecord(r, response))
-		    .findFirst()
-		    .flatMap(r -> ContainerUtils.extractMappedPort(r.getPort(), response.getNetworkSettings()));
-	}
+    private Optional<Integer> findPort(InspectContainerResponse response, List<ServiceRecord> records) {
+        return records.stream()
+                .filter(r -> matchRecord(r, response))
+                .findFirst()
+                .flatMap(r -> ContainerUtils.extractMappedPort(r.getPort(), response.getNetworkSettings()));
+    }
 
-	private boolean matchRecord(ServiceRecord record, InspectContainerResponse r) {
-		return matchIP(record.getServiceAddress(), r) && matchPort(record.getPort(), r);
-	}
+    private boolean matchRecord(ServiceRecord record, InspectContainerResponse r) {
+        return matchIP(record.getServiceAddress(), r) && matchPort(record.getPort(), r);
+    }
 
-
-	private boolean matchPort(int port, InspectContainerResponse r) {
-		return r.getNetworkSettings().getPorts().getBindings().entrySet().stream()
-			.map(entry -> entry.getKey().getPort())
-			.filter(p -> p == port)
-			.findFirst()
-			.isPresent();
-	}
+    private boolean matchPort(int port, InspectContainerResponse r) {
+        return r.getNetworkSettings().getPorts().getBindings().keySet().stream()
+                .map(ExposedPort::getPort)
+                .anyMatch(p -> p == port);
+    }
 
     private boolean matchIP(String address, InspectContainerResponse r) {
-		return null != address && address.equals(ContainerUtils.extractBridgeIpAddress(r.getNetworkSettings()).orElse(null));
-	}
+        return null != address && address.equals(ContainerUtils.extractBridgeIpAddress(r.getNetworkSettings())
+                .orElse(null));
+    }
 
-
-	private Optional<Integer> parsePort(String s) {
+    private Optional<Integer> parsePort(String s) {
         try {
             return Optional.of(Integer.parseInt(s));
         } catch (NumberFormatException nfe) {
             return Optional.empty();
         }
     }
-	
+
 }

--- a/src/main/java/com/github/dockerunit/discovery/consul/ConsulDiscoveryProviderFactory.java
+++ b/src/main/java/com/github/dockerunit/discovery/consul/ConsulDiscoveryProviderFactory.java
@@ -5,9 +5,9 @@ import com.github.dockerunit.core.discovery.DiscoveryProviderFactory;
 
 public class ConsulDiscoveryProviderFactory implements DiscoveryProviderFactory {
 
-	@Override
-	public DiscoveryProvider getProvider() {
-		return new ConsulDiscoveryProvider();
-	}
+    @Override
+    public DiscoveryProvider getProvider() {
+        return new ConsulDiscoveryProvider();
+    }
 
 }

--- a/src/main/java/com/github/dockerunit/discovery/consul/ConsulRegistrator.java
+++ b/src/main/java/com/github/dockerunit/discovery/consul/ConsulRegistrator.java
@@ -1,26 +1,23 @@
 package com.github.dockerunit.discovery.consul;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.model.Container;
-import org.apache.http.HttpResponse;
-import org.apache.http.NoHttpResponseException;
-import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.conn.HttpHostConnectException;
-import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.HttpClientBuilder;
-
 import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.logging.Logger;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.model.Container;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 public class ConsulRegistrator {
 
@@ -40,7 +37,6 @@ public class ConsulRegistrator {
     private final int port;
     private final ObjectWriter objectWriter;
     private final ConsulServiceFactory svcFactory;
-
 
     public ConsulRegistrator(DockerClient client, int pollingPeriod, String consulHost, int consulPort) {
         this.client = client;
@@ -65,7 +61,7 @@ public class ConsulRegistrator {
     }
 
     private void onDestroyHook(Container container) {
-        if(container != null && services.containsKey(container.getId())) {
+        if (container != null && services.containsKey(container.getId())) {
             deregisterSvc(services.get(container.getId()));
             trackers.remove(container.getId());
             services.remove(container.getId());
@@ -77,7 +73,7 @@ public class ConsulRegistrator {
         try {
             executePut("/v1/agent/service/register", objectWriter.writeValueAsString(svc),
                     errorMessage,
-                    ex ->  {
+                    ex -> {
                         throw new RuntimeException(errorMessage.get(), ex);
                     });
         } catch (JsonProcessingException e) {
@@ -86,18 +82,22 @@ public class ConsulRegistrator {
     }
 
     private void deregisterSvc(ConsulService svc) {
-        Supplier<String> errorMessage = () ->"Could not deregister container " + svc.getContainerId() + " from Consul.";
+        Supplier<String> errorMessage = () -> "Could not deregister container " + svc.getContainerId()
+                + " from Consul.";
         executePut("/v1/agent/service/deregister/" + svc.getId(), null,
                 errorMessage,
                 ex -> logger.info("Consul has already stopped. Service de-registration aborted."));
     }
 
-    private void executePut(String endpoint, String body, Supplier<String> errorMessage, Consumer<Exception> onFailure) {
+    private void executePut(String endpoint,
+            String body,
+            Supplier<String> errorMessage,
+            Consumer<Exception> onFailure) {
         HttpPut put = new HttpPut("http://" + host + ":" + port + endpoint);
         put.setHeader(ACCEPT, APPLICATION_JSON);
         put.setHeader(CONTENT_TYPE, APPLICATION_JSON);
 
-        if(body != null) {
+        if (body != null) {
             try {
                 put.setEntity(new StringEntity(body));
             } catch (UnsupportedEncodingException e) {

--- a/src/main/java/com/github/dockerunit/discovery/consul/ServiceRecord.java
+++ b/src/main/java/com/github/dockerunit/discovery/consul/ServiceRecord.java
@@ -4,14 +4,13 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.Wither;
+import lombok.With;
 
-@Wither
+@With
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -48,7 +47,7 @@ public class ServiceRecord {
         return service != null ? service.getPort() : port;
     }
 
-    @Wither
+    @With
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -66,7 +65,7 @@ public class ServiceRecord {
 
     }
 
-    @Wither
+    @With
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor(access = AccessLevel.PRIVATE)


### PR DESCRIPTION
- Consul image by default is going to be pulled by DockerHub while using the consul module. With the new changes, we can specify the docker image
using a system property called `consul.image`.